### PR TITLE
Add port number ot home page instructions

### DIFF
--- a/src/ui/Home.js
+++ b/src/ui/Home.js
@@ -95,7 +95,7 @@ export default class Home extends React.Component {
 		let supported = this.state.supported;
 		let haveperm = this.state.haveperm;
 		let connected = this.state.connected;
-		let url = location.protocol + '//' + location.hostname + '/?';
+		let url = location.protocol + '//' + location.hostname + ':' + location.port + '/?';
 
 		return (
 			<div className="container">


### PR DESCRIPTION
Without this, the instructions in the quick setup, setup, and tips sections will not work correctly when the port number is not 80/443.